### PR TITLE
Fix directional visibility handling

### DIFF
--- a/metar_taf_parser/command/common.py
+++ b/metar_taf_parser/command/common.py
@@ -163,10 +163,10 @@ class VerticalVisibilityCommand:
 
 
 class MinimalVisibilityCommand:
-    regex = r'^(\d{4}[NnEeSsWw])$'
+    regex = r'^(\d{4})(N|NE|E|SE|S|SW|W|NW)$'
 
     def __init__(self):
-        self._pattern = re.compile(MinimalVisibilityCommand.regex)
+        self._pattern = re.compile(MinimalVisibilityCommand.regex, re.IGNORECASE)
 
     def can_parse(self, visibility_string: str):
         return self._pattern.search(visibility_string)
@@ -179,8 +179,10 @@ class MinimalVisibilityCommand:
         :return:
         """
         matches = self._pattern.search(visibility_string).groups()
-        container.visibility.min_distance = int(matches[0][0:4])
-        container.visibility.min_direction = matches[0][4]
+        if container.visibility is None:
+            container.visibility = Visibility()
+        container.visibility.min_distance = int(matches[0])
+        container.visibility.min_direction = matches[1]
         return True
 
 

--- a/metar_taf_parser/tests/command/test_common.py
+++ b/metar_taf_parser/tests/command/test_common.py
@@ -1,8 +1,14 @@
 import unittest
 
-from metar_taf_parser.command.common import CloudCommand, MainVisibilityNauticalMilesCommand, WindCommand, CommandSupplier
+from metar_taf_parser.command.common import (
+    CloudCommand,
+    CommandSupplier,
+    MainVisibilityNauticalMilesCommand,
+    MinimalVisibilityCommand,
+    WindCommand,
+)
 from metar_taf_parser.model.enum import CloudQuantity, CloudType
-from metar_taf_parser.model.model import Metar
+from metar_taf_parser.model.model import TAF, Metar
 
 
 class CommonTestCase(unittest.TestCase):
@@ -89,6 +95,19 @@ class CommonTestCase(unittest.TestCase):
         command = WindCommand()
         metar = Metar()
         self.assertTrue(command.execute(metar, 'VRB08KT'))
+
+    def test_minimal_visibility_command(self):
+        command = MinimalVisibilityCommand()
+
+        for dir in ['N', 'ne', 's', 'SW']:
+            with self.subTest(dir):
+                vis_str = f'3000{dir}'
+                self.assertTrue(command.can_parse(vis_str))
+
+                taf = TAF()
+                self.assertTrue(command.execute(taf, vis_str))
+                self.assertEqual(taf.visibility.min_distance, 3000)
+                self.assertEqual(taf.visibility.min_direction, dir)
 
     def test_main_visibility_nautical_miles_command_with_greater_than(self):
         command = MainVisibilityNauticalMilesCommand()

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -303,7 +303,7 @@ class MetarParserTestCase(unittest.TestCase):
         self.assertEqual('LTAE', metar.station)
         self.assertEqual(1, len(metar.weather_conditions))
         self.assertEqual(Intensity.RECENT, metar.weather_conditions[0].intensity)
-        self.assertEquals(Descriptive.SHOWERS, metar.weather_conditions[0].descriptive)
+        self.assertEqual(Descriptive.SHOWERS, metar.weather_conditions[0].descriptive)
         self.assertEqual(1, len(metar.weather_conditions[0].phenomenons))
         self.assertEqual(Phenomenon.RAIN, metar.weather_conditions[0].phenomenons[0])
 


### PR DESCRIPTION
It's possible that a directional visibility is encountered before the `Visibility` object has been initialized. This change ensures that the `Visibility` is created as needed.

Also add support for intercardinal directions.