### PR TITLE
Fix multiple validity error

### DIFF
--- a/metar_taf_parser/command/common.py
+++ b/metar_taf_parser/command/common.py
@@ -163,10 +163,10 @@ class VerticalVisibilityCommand:
 
 
 class MinimalVisibilityCommand:
-    regex = r'^(\d{4}[NnEeSsWw])$'
+    regex = r'^(\d{4})(N|NE|E|SE|S|SW|W|NW)$'
 
     def __init__(self):
-        self._pattern = re.compile(MinimalVisibilityCommand.regex)
+        self._pattern = re.compile(MinimalVisibilityCommand.regex, re.IGNORECASE)
 
     def can_parse(self, visibility_string: str):
         return self._pattern.search(visibility_string)
@@ -179,8 +179,10 @@ class MinimalVisibilityCommand:
         :return:
         """
         matches = self._pattern.search(visibility_string).groups()
-        container.visibility.min_distance = int(matches[0][0:4])
-        container.visibility.min_direction = matches[0][4]
+        if container.visibility is None:
+            container.visibility = Visibility()
+        container.visibility.min_distance = int(matches[0])
+        container.visibility.min_direction = matches[1]
         return True
 
 

--- a/metar_taf_parser/parser/parser.py
+++ b/metar_taf_parser/parser/parser.py
@@ -10,8 +10,7 @@ from metar_taf_parser.commons import converter
 from metar_taf_parser.commons.exception import TranslationError
 from metar_taf_parser.model.enum import Flag, Intensity, Descriptive, Phenomenon, TimeIndicator, WeatherChangeType
 from metar_taf_parser.model.model import WeatherCondition, Visibility, Metar, TemperatureDated, \
-    AbstractWeatherContainer, TAF, TAFTrend, MetarTrend, Validity, FMValidity, MetarTrendTime
-
+    AbstractWeatherContainer, TAF as TAFData, TAFTrend, MetarTrend, Validity, FMValidity, MetarTrendTime
 
 def parse_delivery_time(abstract_weather_code, time_string):
     """
@@ -261,7 +260,7 @@ class TAFParser(AbstractParser):
         self._taf_command_supplier = TAFCommandSupplier()
 
     def _parse_initial_taf(self, input: str):
-        taf = TAF()
+        taf = TAFData()
         lines = self._extract_lines_tokens(input)
         if TAFParser.TAF != lines[0][0]:
             return
@@ -330,7 +329,7 @@ class TAFParser(AbstractParser):
                 lines_token[len(lines) - 1] = list(filter(lambda x: not x.startswith(TAFParser.TX) and not x.startswith(TAFParser.TN), last_line))
         return lines_token
 
-    def _parse_line(self, taf: 'TAF', line_tokens: list):
+    def _parse_line(self, taf: TAFData, line_tokens: list):
         """
         Parses the tokens of the line and updates the TAF object.
         :param taf: TAF object to update
@@ -392,7 +391,7 @@ class TAFParser(AbstractParser):
                 break
             elif self._validity_or_visibility_pattern.search(line[i]):
                 validity = _parse_validity(line[i])
-                if self._is_valid_validity(validity):
+                if self._is_valid_validity(validity) and getattr(trend, '_validity', None) is None:
                     trend.validity = validity
                 elif visibility := self._parse_visibility(line[i]):
                     trend.visibility = visibility

--- a/metar_taf_parser/tests/command/test_common.py
+++ b/metar_taf_parser/tests/command/test_common.py
@@ -1,8 +1,14 @@
 import unittest
 
-from metar_taf_parser.command.common import CloudCommand, MainVisibilityNauticalMilesCommand, WindCommand, CommandSupplier
+from metar_taf_parser.command.common import (
+    CloudCommand,
+    CommandSupplier,
+    MainVisibilityNauticalMilesCommand,
+    MinimalVisibilityCommand,
+    WindCommand,
+)
 from metar_taf_parser.model.enum import CloudQuantity, CloudType
-from metar_taf_parser.model.model import Metar
+from metar_taf_parser.model.model import TAF, Metar
 
 
 class CommonTestCase(unittest.TestCase):
@@ -89,6 +95,19 @@ class CommonTestCase(unittest.TestCase):
         command = WindCommand()
         metar = Metar()
         self.assertTrue(command.execute(metar, 'VRB08KT'))
+
+    def test_minimal_visibility_command(self):
+        command = MinimalVisibilityCommand()
+
+        for dir in ['N', 'ne', 's', 'SW']:
+            with self.subTest(dir):
+                vis_str = f'3000{dir}'
+                self.assertTrue(command.can_parse(vis_str))
+
+                taf = TAF()
+                self.assertTrue(command.execute(taf, vis_str))
+                self.assertEqual(taf.visibility.min_distance, 3000)
+                self.assertEqual(taf.visibility.min_direction, dir)
 
     def test_main_visibility_nautical_miles_command_with_greater_than(self):
         command = MainVisibilityNauticalMilesCommand()

--- a/metar_taf_parser/tests/command/test_common.py
+++ b/metar_taf_parser/tests/command/test_common.py
@@ -5,7 +5,7 @@ from metar_taf_parser.command.common import (
     CommandSupplier,
     MainVisibilityNauticalMilesCommand,
     MinimalVisibilityCommand,
-    WindCommand,
+    WindCommand
 )
 from metar_taf_parser.model.enum import CloudQuantity, CloudType
 from metar_taf_parser.model.model import TAF, Metar

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -333,6 +333,61 @@ class FunctionTestCase(unittest.TestCase):
 
 
 class TAFParserTestCase(unittest.TestCase):
+    def test_parse_tempo_with_visibility(self):
+        code = """TAF MNMG 260600Z 2306/2406 VRB04KT 9999 FEW020 SCT070
+                    TEMPO 2308/2312 9999/8000 RA/DZ BKN020
+                    TEMPO 2314/2316 09010KT 9800/9000 -DZ SCT022 SCT070
+                    BECMG 2321/2323 7000 -TSRA/RA FEW020CB SCT070
+        """
+        taf = TAFParser().parse(code)
+
+        self.assertEqual(len(taf.trends), 3)
+        trend_1, trend_2, trend_3 = taf.trends
+
+        self.assertEqual(trend_1.type, WeatherChangeType.TEMPO)
+        self.assertEqual(trend_1.validity.start_day, 23)
+        self.assertEqual(trend_1.validity.start_hour, 8)
+        self.assertEqual(trend_1.validity.end_day, 23)
+        self.assertEqual(trend_1.validity.end_hour, 12)
+        self.assertEqual(trend_1.visibility.distance, '> 10km')
+        self.assertEqual(trend_1.visibility.min_distance, 8000)
+        self.assertEqual(len(trend_1.clouds), 1)
+        self.assertEqual(trend_1.clouds[0].height, 2000)
+        self.assertEqual(trend_1.clouds[0].quantity, CloudQuantity.BKN)
+
+        self.assertEqual(trend_2.type, WeatherChangeType.TEMPO)
+        self.assertEqual(trend_2.validity.start_day, 23)
+        self.assertEqual(trend_2.validity.start_hour, 14)
+        self.assertEqual(trend_2.validity.end_day, 23)
+        self.assertEqual(trend_2.validity.end_hour, 16)
+        self.assertEqual(trend_2.wind.degrees, 90)
+        self.assertEqual(trend_2.wind.speed, 10)
+        self.assertEqual(trend_2.visibility.distance, '9800m')
+        self.assertEqual(trend_2.visibility.min_distance, 9000)
+        self.assertEqual(trend_2.wind.speed, 10)
+        self.assertEqual(trend_2.wind.unit, 'KT')
+        self.assertEqual(len(trend_2.clouds), 2)
+        self.assertEqual(trend_2.clouds[0].height, 2200)
+        self.assertEqual(trend_2.clouds[0].quantity, CloudQuantity.SCT)
+        self.assertEqual(trend_2.clouds[1].height, 7000)
+        self.assertEqual(trend_2.clouds[1].quantity, CloudQuantity.SCT)
+        self.assertEqual(len(trend_2.weather_conditions), 1)
+        self.assertEqual(trend_2.weather_conditions[0].intensity, Intensity.LIGHT)
+        self.assertEqual(len(trend_2.weather_conditions[0].phenomenons), 1)
+        self.assertEqual(trend_2.weather_conditions[0].phenomenons[0], Phenomenon.DRIZZLE)
+
+        self.assertEqual(trend_3.type, WeatherChangeType.BECMG)
+        self.assertEqual(trend_3.validity.start_day, 23)
+        self.assertEqual(trend_3.validity.start_hour, 21)
+        self.assertEqual(trend_3.validity.end_day, 23)
+        self.assertEqual(trend_3.validity.end_hour, 23)
+        self.assertEqual(trend_3.visibility.distance, '7000m')
+        self.assertEqual(len(trend_3.clouds), 2)
+        self.assertEqual(trend_3.clouds[0].height, 2000)
+        self.assertEqual(trend_3.clouds[0].quantity, CloudQuantity.FEW)
+        self.assertEqual(trend_3.clouds[0].type, CloudType.CB)
+        self.assertEqual(trend_3.clouds[1].height, 7000)
+        self.assertEqual(trend_3.clouds[1].quantity, CloudQuantity.SCT)
 
     def test_parse_with_invalid_line_breaks(self):
         code = 'TAF LFPG 150500Z 1506/1612 17005KT 6000 SCT012 \n' + 'TEMPO 1506/1509 3000 BR BKN006 PROB40 \n' + 'TEMPO 1506/1508 0400 BCFG BKN002 PROB40 \n' + 'TEMPO 1512/1516 4000 -SHRA FEW030TCU BKN040 \n' + 'BECMG 1520/1522 CAVOK \n' + 'TEMPO 1603/1608 3000 BR BKN006 PROB40 \n TEMPO 1604/1607 0400 BCFG BKN002 TX17/1512Z TN07/1605Z'

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -303,7 +303,7 @@ class MetarParserTestCase(unittest.TestCase):
         self.assertEqual('LTAE', metar.station)
         self.assertEqual(1, len(metar.weather_conditions))
         self.assertEqual(Intensity.RECENT, metar.weather_conditions[0].intensity)
-        self.assertEquals(Descriptive.SHOWERS, metar.weather_conditions[0].descriptive)
+        self.assertEqual(Descriptive.SHOWERS, metar.weather_conditions[0].descriptive)
         self.assertEqual(1, len(metar.weather_conditions[0].phenomenons))
         self.assertEqual(Phenomenon.RAIN, metar.weather_conditions[0].phenomenons[0])
 


### PR DESCRIPTION
Closes https://github.com/springblock-org/knowdelay-delayguard/issues/714

I received an erroneous validity and incorrect visibility interpretation when parsing the following TAF:

```
TAF MNMG 260600Z 2306/2406 VRB04KT 9999 FEW020 SCT070 
                    TEMPO 2308/2312 9999/8000 RA/DZ BKN020 
                    TEMPO 2314/2316 09010KT 9999/9000 -DZ SCT022 SCT070 
                    BECMG 2321/2323 7000 -TSRA/RA FEW020CB SCT070
```

The TEMPO lines had the validity as starting from month 99, day 99 to month 80, day 0 for the first and from month 99, day 99 to month 90 day 0 for the second. This is because the format (`\d{4}/\d{4}`) is identical to the validity.